### PR TITLE
Ignore .curlrc user configuration

### DIFF
--- a/zsh-ai-commands.zsh
+++ b/zsh-ai-commands.zsh
@@ -29,7 +29,7 @@ fzf_ai_commands() {
     ]
   }'
 
-  ZSH_AI_COMMANDS_GTP_RESPONSE=$(curl --silent https://api.openai.com/v1/chat/completions \
+  ZSH_AI_COMMANDS_GTP_RESPONSE=$(curl -q --silent https://api.openai.com/v1/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $ZSH_AI_COMMANDS_OPENAI_API_KEY" \
     -d "$ZSH_AI_COMMANDS_GPT_REQUEST_BODY")


### PR DESCRIPTION
Users can define a [`.curlrc`](https://everything.curl.dev/cmdline/configfile.html) file to customize curl parameters. They can interact badly with `zsh-ai-command` due to unexpected outputs.
